### PR TITLE
Add explicit GOOS=linux in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ godeps:
 	env GOPATH="${GOPATH}" go get
 
 build:
-	env GOPATH="${GOPATH}" go build -o bin/go-aws-mon
+	env GOOS=linux GOPATH="${GOPATH}" go build -o bin/go-aws-mon
 
 deps:
 	


### PR DESCRIPTION
This allows developers using Mac OSX (or others) to build the the binary for linux.
